### PR TITLE
Add docker role (currently broken)

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,0 +1,31 @@
+- name: Docker Repo
+  become: yes
+  zypper_repository:
+    name: docker-main
+    repo: https://yum.dockerproject.org/repo/main/opensuse/13.2/
+    auto_import_keys: yes
+
+- name: Docker is Installed
+  become: yes
+  zypper:
+    name: docker-engine
+    state: latest
+
+- name: Create Docker group
+  become: yes
+  group:
+    name: docker
+    state: present
+
+- name: Add Current User to Docker group
+  become: yes
+  user:
+    name: "{{ ansible_env.USER }}"
+    groups: docker
+    append: yes
+
+- name: Start Docker Service
+  become: yes
+  service:
+    name: docker
+    state: started

--- a/setup.yml
+++ b/setup.yml
@@ -3,6 +3,7 @@
   connection: local
   roles:
     - cli
+    - docker
     - vim
     - gnomeshell
     - gnomeshell-theme


### PR DESCRIPTION
This is currently broken because

* cant autoimport gpg key
* even if it is done manually, `docker-engine-1.13` is signed by the wrong key :man_facepalming: 